### PR TITLE
Adds support for setting config options of the rust lsp server

### DIFF
--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -12,6 +12,8 @@
 (require 'lsp-mode)
 (require 'json)
 
+(defvar lsp-rust--config-options (make-hash-table))
+
 (defun lsp-rust--rls-command ()
   (let ((rls-root (getenv "RLS_ROOT"))
 	(rls-path (executable-find "rls")))
@@ -45,4 +47,30 @@
 			    #'(lambda (_w _p)))
 (lsp-client-on-notification 'rust-mode "rustDocument/diagnosticsEnd"
 			    #'(lambda (_w _p)))
+
+(defun lsp-rust--set-configuration ()
+  (lsp--set-configuration `(:rust , lsp-rust--config-options)))
+
+(add-hook 'lsp-after-initialize-hook 'lsp-rust--set-configuration)
+
+(defun lsp-rust-set-config (name option)
+  "Set a config option in the rust lsp server."
+  (puthash name option lsp-rust--config-options))
+
+(defun lsp-rust-set-build-lib (build)
+  "Enable(t)/Disable(nil) building the lib target."
+  (lsp-rust-set-config "build_lib" build))
+
+(defun lsp-rust-set-build-bin (build)
+  "The bin target to build."
+  (lsp-rust-set-config "build_bin" build))
+
+(defun lsp-rust-set-cfg-test (val)
+  "Enable(t)/Disable(nil) #[cfg(test)]."
+  (lsp-rust-set-config "cfg_test" val))
+
+(defun lsp-rust-set-goto-def-racer-fallback (val)
+  "Enable(t)/Disable(nil) goto-definition should use racer as fallback."
+  (lsp-rust-set-config "goto_def_racer_fallback" val))
+
 (provide 'lsp-rust)


### PR DESCRIPTION
I did not add all possible configuration options, but the function lsp-rust-set-config can be used for setting all supported options.

Requires: https://github.com/emacs-lsp/lsp-mode/pull/109