### PR TITLE
Implement rustDocument/beginBuild LSP extension

### DIFF
--- a/lsp-rust.el
+++ b/lsp-rust.el
@@ -63,11 +63,11 @@
     ("rustDocument/diagnosticsEnd" .
      (lambda (w _p)
        (when (< (cl-decf (gethash w lsp-rust--diag-counters 0)) 0)
-	 (message "RLS: done"))))
+	 (setq lsp-status nil))))
     ("rustDocument/beginBuild" .
      (lambda (w _p)
        (cl-incf (gethash w lsp-rust--diag-counters 0))
-       (message "RLS: working")))))
+       (setq lsp-status "(building)")))))
 
 (defun lsp-rust--render-string (str)
   (with-temp-buffer


### PR DESCRIPTION
This changes the mode-line to notify users that the RLS has started working.

This requires that emacs/lsp-mode#134 has been merged first.